### PR TITLE
Migrate xmldom to @xmldom/xmldom

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn run xsd-ts example/greeting.xsd example/greeting.ts
 ```ts
 // feed xml dom into parser to get the typed valid object structure
 import { readFileSync } from 'fs';
-import { DOMParser } from 'xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 import parse from './greeting.ts';
 
 const xml = readFileSync('example/greeting.xml', 'utf8');

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xsd-tools/example",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Examples for xsd-tools",
   "author": "David Knezić <davidknezic@gmail.com>",
@@ -18,12 +18,12 @@
     "url": "https://github.com/pocketbitcoin/xsd-tools/issues"
   },
   "dependencies": {
-    "xmldom": "^0.6.0",
-    "xsd-tools": "^0.1.1"
+    "@xmldom/xmldom": "^0.8.7",
+    "xsd-tools": "^0.2.1"
   },
   "devDependencies": {
     "@types/xmldom": "^0.1.31",
-    "@xsd-tools/typescript": "^0.1.1",
+    "@xsd-tools/typescript": "^0.2.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   }

--- a/example/src/example.ts
+++ b/example/src/example.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { DOMParser } from 'xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 import parse from './greeting';
 
 const xml = readFileSync(resolve(__dirname, '../greeting.xml'), 'utf8');

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xsd-tools/typescript",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Schema-driven XML parser generator for TypeScript",
   "keywords": [
     "xsd",
@@ -40,13 +40,13 @@
   },
   "peerDependencies": {
     "typescript": "^4.0.0",
-    "xsd-tools": "^0.1.0"
+    "xsd-tools": "^0.2.1"
   },
   "dependencies": {
+    "@xmldom/xmldom": "^0.8.7",
     "commander": "^10.0.0",
     "node-fetch": "^2.0.0",
-    "unzipper": "^0.10.11",
-    "xmldom": "^0.6.0"
+    "unzipper": "^0.10.11"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.0.0",
@@ -54,6 +54,6 @@
     "@types/xmldom": "^0.1.31",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5",
-    "xsd-tools": "^0.2.0"
+    "xsd-tools": "^0.2.1"
   }
 }

--- a/packages/typescript/src/bin/xsd-ts.ts
+++ b/packages/typescript/src/bin/xsd-ts.ts
@@ -3,7 +3,7 @@
 import { writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { Command } from 'commander';
-import { DOMParser } from 'xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 import { generate } from '../generate';
 import fetchFile from '../fetch';
 

--- a/packages/xsd-tools/package.json
+++ b/packages/xsd-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xsd-tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Essentials for schema-driven, type-safe XML processing",
   "keywords": [
     "xsd",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/xmldom": "^0.1.31",
-    "typescript": "^4.9.5",
-    "xmldom": "^0.6.0"
+    "@xmldom/xmldom": "^0.8.7",
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
First, thank you for your great work on this package. I found it greatly suitable for one of my projects.

However, I found that `@xsd-tools/typescript` package depends on `xmldom`, which has a security issue and is no longer maintained; it has migrated to `@xmldom/xmldom`.
Please take a look at this issue: <https://github.com/xmldom/xmldom/issues/271>

In addition, I found that the peer dependency of `xsd-tools^0.1.0` from `@xsd-tools/typescript` is incompatible with the latest version of `xsd-tools@0.2.0`. Please review and make relevant changes.

I hope you have a nice day!

Sincerely,
Jinhyeon.
